### PR TITLE
Fixes symlinks, making them keep their structure

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -169,8 +169,11 @@ impl CopyWorker {
                 }
                 
                 if is_link {
-                    std::os::unix::fs::symlink(&p, &dest_file).unwrap_or(()); // FIXME 
-                    // std::os::unix::fs::symlink(&p, &dest_file).unwrap(); // FIXME 
+                    let link_dest = std::fs::read_link(&p).unwrap();
+                    std::os::unix::fs::symlink(&link_dest, &dest_file).unwrap_or_else(|err| {
+                        eprintln!("Error creating symlink: {}", err);
+                        ()
+                    }); // FIXME 
                     tx.send((p, sz as u32, sz, sz)).unwrap();
                     continue;
                 }


### PR DESCRIPTION
Hey!

The old behaviour was creating a symlink to the original symlink, which (I believe) is not expected when COPYING. 

This makes it create a symlink to wherever the old symlink points to, keeping its type (relative or absolute).